### PR TITLE
Add `hide_images` option to to disable fetching, storing and displaying of images

### DIFF
--- a/script-opts/jellyfin.conf
+++ b/script-opts/jellyfin.conf
@@ -11,15 +11,15 @@ username=
 # ex. pass123
 password=
 
-# Display banner images for libraries, folders and media
-# Defaults to on
-# ex. off
-show_images=
-
 # The system path to store images
 # ex. /tmp/mpv-jellyfin
 # or /home/billy/.cache/mpv-jellyfin
 image_path=
+
+# Display banner images for libraries, folders and media
+# Defaults to off
+# ex. on
+hide_images=
 
 # Should descriptions be hidden if the item hasn't been watched yet
 # Defaults to on

--- a/script-opts/jellyfin.conf
+++ b/script-opts/jellyfin.conf
@@ -11,6 +11,11 @@ username=
 # ex. pass123
 password=
 
+# Display banner images for libraries, folders and media
+# Defaults to on
+# ex. off
+show_images=
+
 # The system path to store images
 # ex. /tmp/mpv-jellyfin
 # or /home/billy/.cache/mpv-jellyfin

--- a/scripts/jellyfin.lua
+++ b/scripts/jellyfin.lua
@@ -10,8 +10,8 @@ local options = {
     url = "",
     username = "",
     password = "",
-    show_images = "on",
     image_path = "",
+    hide_images = "",
     hide_spoilers = "on",
     show_by_default = "",
     use_playlist = "",
@@ -240,7 +240,7 @@ end
 local function update_data()
     update_list()
     local item = items[selection[layer]]
-    if options.show_images ~= "off" then update_image(item) end
+    if options.hide_images ~= "on" then update_image(item) end
     update_metadata(item)
 end
 
@@ -477,7 +477,7 @@ end
 mp.add_periodic_timer(1, check_percent)
 mp.add_key_binding("Ctrl+j", "jf", toggle_overlay)
 mp.add_key_binding("ESC", nil, disable_overlay)
-if options.show_images ~= "off" then
+if options.hide_images ~= "on" then
     mkdir(options.image_path)
     mp.observe_property("osd-width", "number", width_change)
 end

--- a/scripts/jellyfin.lua
+++ b/scripts/jellyfin.lua
@@ -10,6 +10,7 @@ local options = {
     url = "",
     username = "",
     password = "",
+    show_images = "on",
     image_path = "",
     hide_spoilers = "on",
     show_by_default = "",
@@ -239,7 +240,7 @@ end
 local function update_data()
     update_list()
     local item = items[selection[layer]]
-    update_image(item)
+    if options.show_images ~= "off" then update_image(item) end
     update_metadata(item)
 end
 
@@ -473,11 +474,13 @@ local function align_y_change(name, data)
     set_align()
 end
 
-mkdir(options.image_path)
 mp.add_periodic_timer(1, check_percent)
 mp.add_key_binding("Ctrl+j", "jf", toggle_overlay)
 mp.add_key_binding("ESC", nil, disable_overlay)
-mp.observe_property("osd-width", "number", width_change)
+if options.show_images ~= "off" then
+    mkdir(options.image_path)
+    mp.observe_property("osd-width", "number", width_change)
+end
 mp.observe_property("osd-align-x", "string", align_x_change)
 mp.observe_property("osd-align-y", "string", align_y_change)
 mp.register_event("end-file", unpause)


### PR DESCRIPTION
Thank you for this amazing script. I added an option for myself to be able to disable image loading since I don't need them. Filed a PR just in case others would be interested in this. Images are shown by default and require user intervention to disable. So the default behaviour is preserved.

Thank you again.