### PR TITLE
Add `show_on_idle` option to enable the script UI once playback has ended

### DIFF
--- a/script-opts/jellyfin.conf
+++ b/script-opts/jellyfin.conf
@@ -31,6 +31,13 @@ hide_spoilers=
 # ex. on
 show_by_default=
 
+# Show the script's UI again once file playback has ended. Requires
+# mpv to be started with the --idle flag so that the window persists
+# after playback has finished.
+# Defaults to off
+# ex. on
+show_on_idle=
+
 # Replace the current playlist when you play a video
 # Defaults to off
 # ex. on

--- a/scripts/jellyfin.lua
+++ b/scripts/jellyfin.lua
@@ -14,6 +14,7 @@ local options = {
     hide_images = "",
     hide_spoilers = "on",
     show_by_default = "",
+    show_on_idle = "",
     use_playlist = "",
     colour_default = "FFFFFF",
     colour_selected = "FF",
@@ -474,6 +475,12 @@ local function align_y_change(name, data)
     set_align()
 end
 
+local function enable_overlay_on_idle()
+    if mp.get_property_bool("idle-active") and not shown then
+        toggle_overlay()
+    end
+end
+
 mp.add_periodic_timer(1, check_percent)
 mp.add_key_binding("Ctrl+j", "jf", toggle_overlay)
 mp.add_key_binding("ESC", nil, disable_overlay)
@@ -488,3 +495,6 @@ if input_success then
     mp.add_key_binding("Ctrl+f", "jf_search", search_input)
 end
 if options.show_by_default == "on" then toggle_overlay() end
+if options.show_on_idle == "on" then
+    mp.observe_property("idle-active", "bool", enable_overlay_on_idle)
+end

--- a/scripts/jellyfin.lua
+++ b/scripts/jellyfin.lua
@@ -475,8 +475,8 @@ local function align_y_change(name, data)
     set_align()
 end
 
-local function enable_overlay_on_idle()
-    if mp.get_property_bool("idle-active") and not shown then
+local function enable_overlay_on_idle(_, is_idle)
+    if is_idle and not shown then
         toggle_overlay()
     end
 end


### PR DESCRIPTION
If this option is enabled and mpv is started with the `--idle` flag, the script UI is reshown once playback finished,